### PR TITLE
Fixes bug Ankit encountered early with EditProfile

### DIFF
--- a/client/src/components/EditProfile/EditProfileTab/EditProfileTab.tsx
+++ b/client/src/components/EditProfile/EditProfileTab/EditProfileTab.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { useFormik } from 'formik';
 import edit from '../../../helpers/APICalls/edit';
 import fetchProfile from '../../../helpers/APICalls/fetchProfile';
+import { mockId } from '../../../mocks/mockId';
 
 interface Profile {
   firstName: string;
@@ -52,10 +53,9 @@ export default function EditProfileTab(): JSX.Element {
     gender: '',
     email: '',
   });
-  const userId = '619c1eb37a1e963a5b179c4b';
 
   useEffect(() => {
-    fetchProfile(userId).then((data) => setProfile(data.success.profile)); //get profileValues and set to profile state
+    fetchProfile(mockId).then((data) => setProfile(data.success.profile)); //get profileValues and set to profile state
   }, []);
 
   const formik = useFormik({
@@ -75,7 +75,7 @@ export default function EditProfileTab(): JSX.Element {
     },
     onSubmit: (values) => {
       edit(
-        userId,
+        mockId,
         values.firstName,
         values.lastName,
         values.description,

--- a/client/src/mocks/mockId.tsx
+++ b/client/src/mocks/mockId.tsx
@@ -1,0 +1,1 @@
+export const mockId = '619c1eb37a1e963a5b179c4b';


### PR DESCRIPTION
added mockId that users must change to their id when running the app

when running the app, the user must change the mockId in client/mocks/mock.tsx to the id of their user