### PR TITLE
IN Notification Sockets

### DIFF
--- a/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
+++ b/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
@@ -5,16 +5,26 @@ import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import AuthMenu from '../../AuthMenu/AuthMenu';
 import Notifications from './Notifications/Notifications';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import getUnread from '../../../helpers/APICalls/getAllUnreadNotifications';
 import readNotification from '../../../helpers/APICalls/readNotification';
 import { notification } from '../../../interface/Notification';
+import { AuthContext } from '../../../context/useAuthContext';
+import { SocketContext } from '../../../context/useSocketContext';
 
 const LoggedInBar = (): JSX.Element => {
+  const { loggedInUser } = useContext(AuthContext);
+  const { socket } = useContext(SocketContext);
   const classes = useStyles();
   const [unread, setUnread] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [notifications, setNotifications] = useState<notification[]>([]);
+
+  socket?.emit('get unread notifications', loggedInUser?.id);
+
+  socket?.on('new unread notifications', (notificationsDataFromSockets) => {
+    console.log(notificationsDataFromSockets);
+  });
 
   useEffect(() => {
     getUnread().then((data) => {
@@ -41,12 +51,13 @@ const LoggedInBar = (): JSX.Element => {
 
   const handleNotificationsOpen = () => {
     setNotificationsOpen(!notificationsOpen); //open notifications dropdown
-    setUnread(false); //turn off unread indicator
-    if (notificationsOpen) {
-      notifications.forEach((notification) => {
-        readNotification(notification._id); //set notification read status as true
-      });
-    }
+    socket?.emit('read notifications');
+    // setUnread(false); //turn off unread indicator
+    // if (notificationsOpen) {
+    //   notifications.forEach((notification) => {
+    //     readNotification(notification._id); //set notification read status as true
+    //   });
+    // }
   };
 
   return (

--- a/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
+++ b/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
@@ -5,9 +5,7 @@ import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import AuthMenu from '../../AuthMenu/AuthMenu';
 import Notifications from './Notifications/Notifications';
-import { useState, useEffect, useContext } from 'react';
-import getUnread from '../../../helpers/APICalls/getAllUnreadNotifications';
-import readNotification from '../../../helpers/APICalls/readNotification';
+import { useState, useContext } from 'react';
 import { notification } from '../../../interface/Notification';
 import { AuthContext } from '../../../context/useAuthContext';
 import { SocketContext } from '../../../context/useSocketContext';
@@ -23,47 +21,28 @@ const LoggedInBar = (): JSX.Element => {
   socket?.emit('get unread notifications', loggedInUser?.id);
 
   socket?.on('new unread notifications', (notificationsDataFromSockets) => {
-    console.log(notificationsDataFromSockets);
+    setNotifications(notificationsDataFromSockets);
+    if (notificationsDataFromSockets.length > 0) {
+      setUnread(true);
+    } else {
+      setUnread(false);
+    }
   });
 
-  useEffect(() => {
-    getUnread().then((data) => {
-      const notificationsData = data.success?.notifications;
-      const notificationsArray: notification[] = [
-        {
-          type: '',
-          title: '',
-          description: '',
-          read: false,
-          createdAt: new Date('1/1/2000'),
-          image: '',
-          _id: '',
-        },
-      ];
-      notificationsData?.forEach((n) => notificationsArray.push(n));
-      notificationsArray.shift();
-      setNotifications(notificationsArray);
-      if (notificationsArray.length > 0) {
-        setUnread(true);
+  const handleNotificationButtonClick = () => {
+    setNotificationsOpen(!notificationsOpen);
+    if (notificationsOpen) {
+      setUnread(false); //turn off unread indicator
+      if (notifications.length) {
+        socket?.emit('read notifications', notifications);
       }
-    });
-  }, []);
-
-  const handleNotificationsOpen = () => {
-    setNotificationsOpen(!notificationsOpen); //open notifications dropdown
-    socket?.emit('read notifications');
-    // setUnread(false); //turn off unread indicator
-    // if (notificationsOpen) {
-    //   notifications.forEach((notification) => {
-    //     readNotification(notification._id); //set notification read status as true
-    //   });
-    // }
+    }
   };
 
   return (
     <Grid container className={classes.navButtons}>
       <Grid item>
-        <Button onClick={(e) => handleNotificationsOpen()} color="secondary" size="large" variant="text">
+        <Button onClick={() => handleNotificationButtonClick()} color="secondary" size="large" variant="text">
           <Typography variant="h3">Notifications</Typography>
           {unread && <Typography className={classes.indicator}></Typography>}
           {notificationsOpen && <Notifications notifications={notifications} />}

--- a/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
+++ b/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
@@ -18,6 +18,7 @@ const LoggedInBar = (): JSX.Element => {
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [notifications, setNotifications] = useState<notification[]>([]);
 
+  socket?.emit('join', { id: loggedInUser?.id });
   socket?.emit('get unread notifications', loggedInUser?.id);
 
   socket?.on('new unread notifications', (notificationsDataFromSockets) => {

--- a/client/src/context/useSocketContext.tsx
+++ b/client/src/context/useSocketContext.tsx
@@ -1,29 +1,42 @@
 import { useState, useContext, createContext, FunctionComponent, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { useAuth } from './useAuthContext';
 
 interface ISocketContext {
   socket: Socket | undefined;
   initSocket: () => void;
+  disconnect: () => void;
 }
 
 export const SocketContext = createContext<ISocketContext>({
   socket: undefined,
   initSocket: () => null,
+  disconnect: () => null,
 });
 
 export const SocketProvider: FunctionComponent = ({ children }): JSX.Element => {
   const [socket, setSocket] = useState<Socket | undefined>(undefined);
+  const { loggedInUser } = useAuth();
 
   const initSocket = useCallback(() => {
-    console.log('trying to connect');
-    setSocket(
-      io('/', {
-        withCredentials: true,
-      }),
-    );
-  }, []);
+    if (loggedInUser && !socket) {
+      setSocket(
+        io('/', {
+          withCredentials: true,
+        }),
+      );
+    } else if (!loggedInUser && socket) {
+      socket.disconnect();
+    }
+  }, [loggedInUser, socket]);
 
-  return <SocketContext.Provider value={{ socket, initSocket }}>{children}</SocketContext.Provider>;
+  const disconnect = useCallback(() => {
+    if (socket) {
+      socket.disconnect();
+    }
+  }, [socket]);
+
+  return <SocketContext.Provider value={{ socket, initSocket, disconnect }}>{children}</SocketContext.Provider>;
 };
 
 export function useSocket(): ISocketContext {

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,8 +1,19 @@
+import { useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
+import { useSocket } from '../../context/useSocketContext';
 import useStyles from './useStyles';
 
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();
+  const { initSocket, disconnect } = useSocket();
+
+  useEffect(() => {
+    initSocket();
+
+    return () => {
+      disconnect();
+    };
+  }, [initSocket, disconnect]);
 
   return <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}></Grid>;
 }

--- a/server/app.js
+++ b/server/app.js
@@ -60,13 +60,15 @@ io.use((socket, next) => {
   }
 }).on("connection", (socket) => {
   console.log(Array.from(loggedInUsers.values()));
+  socket.on("join", (data) => {
+    socket.join(data.id);
+  });
   socket.on("get unread notifications", (id) => {
     Notification.find({ recipient: id, read: false }).then((notifications) => {
-      io.emit("new unread notifications", notifications);
+      io.sockets.in(id).emit("new unread notifications", notifications);
     });
   });
   socket.on("read notifications", (notifications) => {
-    console.log("read notification trigger");
     notifications.forEach((notification) => {
       Notification.findById(notification._id)
         .then((n) => {
@@ -75,9 +77,6 @@ io.use((socket, next) => {
         })
         .then((n) => {
           n.save();
-        })
-        .then(() => {
-          console.log("notification read");
         });
     });
   });

--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ const connectDB = require("./db");
 const { notFound, errorHandler } = require("./middleware/error");
 
 const User = require("./models/User");
+const Notification = require("./models/Notifications");
 const authRouter = require("./routes/auth");
 const userRouter = require("./routes/user");
 const profileRouter = require("./routes/profile");
@@ -59,6 +60,10 @@ io.use((socket, next) => {
   }
 }).on("connection", (socket) => {
   console.log(Array.from(loggedInUsers.values()));
+  socket.on("get unread notifications", (id) => {
+    const notifications = await Notification.find({ recipient: id, read: false });
+    io.emit("new unread notifications", notifications);
+  });
   socket.on("disconnect", () => {
     loggedInUsers.delete(socket);
     console.log(Array.from(loggedInUsers.values()));

--- a/server/app.js
+++ b/server/app.js
@@ -61,8 +61,25 @@ io.use((socket, next) => {
 }).on("connection", (socket) => {
   console.log(Array.from(loggedInUsers.values()));
   socket.on("get unread notifications", (id) => {
-    const notifications = await Notification.find({ recipient: id, read: false });
-    io.emit("new unread notifications", notifications);
+    Notification.find({ recipient: id, read: false }).then((notifications) => {
+      io.emit("new unread notifications", notifications);
+    });
+  });
+  socket.on("read notifications", (notifications) => {
+    console.log("read notification trigger");
+    notifications.forEach((notification) => {
+      Notification.findById(notification._id)
+        .then((n) => {
+          n.read = true;
+          return n;
+        })
+        .then((n) => {
+          n.save();
+        })
+        .then(() => {
+          console.log("notification read");
+        });
+    });
   });
   socket.on("disconnect", () => {
     loggedInUsers.delete(socket);

--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -5,8 +5,7 @@ const asyncHandler = require("express-async-handler");
 // @desc create new notification
 // @access Public
 exports.createNotification = asyncHandler(async (req, res, next) => {
-  const notification = new Notification(({ type, title, description, read, date, image, recipient } = req.body));
-
+  const notification = new Notification(({ type, title, description, read, recipient, image } = req.body));
   const newNotification = await notification.save();
   res.status(200).json({
     success: {

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -8,7 +8,7 @@ const {
   getUnreadNotifications,
 } = require("../controllers/notification");
 
-router.route("/create").post(protect, createNotification);
+router.route("/create").post(createNotification);
 
 router.route("/read/:id").patch(protect, readNotification);
 


### PR DESCRIPTION
### What this PR does (required):
- addresses #60 
- integrates sockets for notifications

### Any information needed to test this feature (required):
- run server and client
- open notification dropdown if there are any unread notifications (will show green dot indicator if so)
   - close notification dropdown (marks all as read)
- create new notification via Postman and set read to false (unread notification)
   - once MongoDB is updated, the green indicator should appear without having to refresh the page
- closing the dropdown will mark that notification as read = true in MongoDB (double-check to verify)

### Any issues with the current functionality (optional):
- I am able to test the functionality by manually changing notifications' read property to true/false, but the update triggered by the 'read notifications' socket event is very slow
   - there is a considerable lag between the triggering of the 'read notifications' socket listener and the update to the notification in MongoDB (check the timing of log messages to server)
